### PR TITLE
Add button component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules
 __clientTemp
 www/styles
+www/components

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,0 +1,27 @@
+import { Link } from 'react-server';
+
+export default (props) => {
+	let { onClick, href, clientTransition, bundleData, reuseDom, frameback, reuseFrame, path, target } = props;
+	href = href || path || target;
+
+	if (!href) {
+		return (
+			<button {...props} className="button">
+				{props.children}
+			</button>
+		);
+	} else if (!clientTransition) {
+		return (
+			<a className="button" href={href}>
+				{props.children}
+			</a>
+		);
+	} else {
+		return (
+			<Link
+				path={href}
+				{...props}
+				className="button">{props.children}</Link>
+		);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "homepage": "https://github.com/careylin/ui-kit#readme",
   "devDependencies": {
     "node-sass": "^3.6.0",
-    "babel-plugin-transform-runtime": "~6.5",
-    "babel-preset-es2015": "~6.5",
+    "babel-plugin-transform-runtime": "^6.8.0",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "~6.5",
-    "babel-runtime": "~6.5",
-    "react": "~0.14.2",
-    "react-dom": "~0.14.2",
-    "react-server": "~0.1.5",
-    "react-server-cli": "~0.1.5",
+    "babel-runtime": "^6.6.1",
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2",
+    "react-server": "^0.2.6",
+    "react-server-cli": "^0.2.6",
     "superagent": "1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "sassify": "node-sass styles/index.scss www/styles/index.css",
-    "start": "react-server-cli --routes=www/routes.js"
+    "componentify": "mkdir -p www/components && cp components/* www/components",
+    "start": "react-server-cli --routes=www/routes.js",
+    "clean": "rm -r __clientTemp www/components www/styles",
+    "build": "npm run componentify && npm run sassify"
   },
   "repository": {
     "type": "git",
@@ -17,6 +20,7 @@
     "ui-kit"
   ],
   "author": "Carey Spies",
+  "contributors": [ "Doug Wade <doug@dougwade.io>" ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/careylin/ui-kit/issues"
@@ -33,5 +37,8 @@
     "react-server": "^0.2.6",
     "react-server-cli": "^0.2.6",
     "superagent": "1.2.0"
+  },
+  "peerDependencies": {
+    "react-server": "^0.2.6"
   }
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -25,7 +25,7 @@ body{
   color:$vanta;
 }
 
-button{
+.button{
   font:$font-stack;
   font-weight:500;
   @include border-radius(3px);

--- a/www/index.js
+++ b/www/index.js
@@ -1,4 +1,5 @@
-import React from "react"
+import React from 'react'
+import Button from './components/Button.js'
 import './styles/index.css'
 
 export default class SimplePage {
@@ -9,10 +10,9 @@ export default class SimplePage {
 			<h2>Heading 2</h2>
 			<h3>Heading 3</h3>
 			<hr/>
-			<button>Click Me</button>
-			<button>Love Me</button>
-			<button>Press my Buttons</button>
-
-			</div>		);
+			<Button>Click Me</Button>
+			<Button href="/transition">Love Me</Button>
+			<Button href="/transition" clientTransition={true} reuseDom={true}>Press my Buttons</Button>
+		</div>);
 	}
 }

--- a/www/routes.js
+++ b/www/routes.js
@@ -1,9 +1,14 @@
 module.exports = {
 	routes: {
-		HelloWorld: {
+		Index: {
 			path: ['/'],
 			method: 'get',
-			page: "./index",
+			page: './index',
+		},
+		Transition: {
+			path: ['/transition'],
+			method: 'get',
+			page: './transition',
 		},
 	},
 };

--- a/www/transition.js
+++ b/www/transition.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default class TransitionPage {
+	getElements () {
+		return (
+		<div>
+			<h1>You successfully navigated!</h1>
+		</div>);
+	}
+}


### PR DESCRIPTION
Adds a button component that wraps `Link` for [client transitions](https://github.com/redfin/react-server/blob/master/docs/client-transitions.md).  Note that `Link` buttons don't transclude classes to the underlying anchor tags, so until [this pr](https://github.com/redfin/react-server/pull/156) merges is published, client transition link buttons will look a little goofy:
<img width="336" alt="screen shot 2016-05-15 at 2 07 26 pm" src="https://cloud.githubusercontent.com/assets/3477707/15276770/8478664e-1aa6-11e6-9aff-35466a487184.png">
